### PR TITLE
chore: Laravel 12 / 13 に対応する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     },
     "authors": [
-    {
-        "name": "zaxxas",
-        "email": "zaxxxxxas@gmail.com"
+        {
+            "name": "zaxxas",
+            "email": "zaxxxxxas@gmail.com"
         }
     ],
     "require": {
-        "php": "^8.4.0",
-        "guzzlehttp/guzzle": "^7.5",
-        "illuminate/collections": "^9.0 || ^10.0 || ^11.0"
+        "php": "^8.2.0",
+        "guzzlehttp/guzzle": "^7.10 || ^8.0",
+        "illuminate/collections": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.1",
-        "orchestra/testbench": "^8.0"
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "scripts": {
         "test": [

--- a/tests/LineNotificationTest.php
+++ b/tests/LineNotificationTest.php
@@ -52,8 +52,8 @@ class LineNotificationTest extends TestCase
 
     public function test_succeeded_to_send_a_message()
     {
-        Config::set('notification.line.endpoint_url', Env::get('LINE_API_ENDPOINT'));
-        Config::set('notification.line.token', Env::get('LINE_API_TOKEN'));
+        Config::set('notification.line.endpoint_url', 'https://test.line');
+        Config::set('notification.line.token', 'dummy-line-token');
 
         $messageContent = new NotificationMessageContent(
             title: '',


### PR DESCRIPTION
## 背景

利用側（museum-platform）で **Laravel 11 の全バージョン（11.31〜11.55）にセキュリティ勧告**が出ており、修正版が存在しないため 12 以降へ上げる必要があります。

しかしこのパッケージが `illuminate/collections ^9.0 || ^10.0 || ^11.0` 止まりで、**フレームワークのアップグレードをブロックしていました**。

```
Only one of these can be installed:
  illuminate/collections[...v11.51.0, v12.0.0, ..., v13.24.0], laravel/framework[v13.24.0]
```

## 変更

| 対象 | 変更 |
|---|---|
| `illuminate/collections` | `^12.0 \|\| ^13.0` を追加 |
| `guzzlehttp/guzzle` | `^7.5` → `^7.10 \|\| ^8.0`（7.9 以前は勧告対象） |
| `php` | `^8.4.0` → `^8.2.0`（不必要に狭かった） |
| `phpunit` / `orchestra/testbench` | 対応バージョンを追加 |

## 確認

利用側で **Laravel 13.24.0 まで含めて全依存が解決可能**であることを確認済みです。

テストの env 依存も外しました（`LINE_API_*` が無い環境で落ちるため）。外部サービスへ実送信する 4 件は認証情報が無いと失敗しますが、**これは変更前からの状態**です（退避して確認済み）。

## マージ後

`v0.10.0` としてタグを打てば、利用側で Laravel 13 化を進められます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)